### PR TITLE
making demo.sh not depend on calling directory

### DIFF
--- a/bin/demo.sh
+++ b/bin/demo.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+repo_root="$DIR/.."
+pushd "$repo_root" >/dev/null
 
 WORKLOAD="workloads/demowork"
 
@@ -40,5 +44,7 @@ echo "*****************"
 
 echo "6. Starting Agar client..."
 ./bin/ycsb run agar -P $WORKLOAD -demo
+
+popd >/dev/null
 
 exit 0


### PR DESCRIPTION
this allows the `bin/demo.sh` script to work regardless of where it was called from